### PR TITLE
Моды "Russian Chat" и "Russian Localization" взаимоисключающие.

### DIFF
--- a/meta/mod.js
+++ b/meta/mod.js
@@ -1,7 +1,22 @@
+var mutuallyExclusiveComponents = ["wakfu.mod.chat"];
+
 function Component()
 {
+	component.valueChanged.connect(this, Component.prototype.valueChanged);
     var modname = component.name.substring(component.name.lastIndexOf('.') + 1);
     component.registerPathForUninstallation("@WAKFU_MODS@/" + modname, true);
+}
+
+Component.prototype.valueChanged = function (key, value)
+{
+    var page = gui.currentPageWidget();
+    if (page != null && page == gui.pageById(QInstaller.ComponentSelection)) {
+        if (key == "UncompressedSizeSum" && value > 0) {
+            for (var i = 0; i < mutuallyExclusiveComponents.length; i++) {
+                page.deselectComponent(mutuallyExclusiveComponents[i]);
+            }
+        }
+    }
 }
 
 Component.prototype.createOperations = function()

--- a/meta/package.xml
+++ b/meta/package.xml
@@ -3,8 +3,8 @@
     <DisplayName>Russian Localization</DisplayName>
     <Description xml:lang="en">Russian Localization. Translated: https://github.com/Valianton/Wakfu-Translate</Description>
     <Description xml:lang="ru">Руссификация Wakfu. Перевод: https://github.com/Valianton/Wakfu-Translate</Description>
-    <Version>1.6.6</Version>
-    <ReleaseDate>2017-05-29</ReleaseDate>
+    <Version>1.6.7</Version>
+    <ReleaseDate>2017-05-30</ReleaseDate>
     <SortingPriority>100</SortingPriority>
     <Default>true</Default>
     <Script>mod.js</Script>


### PR DESCRIPTION
Моды "Russian Chat" и "Russian Localization" теперь взаимоисключающие. Можно установить либо один либо другой, но не оба сразу. Во избежание конфликтов между ними.